### PR TITLE
DON'T ACCEPT AS-IS: Patch 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ node_js:
 
 before_script:
   - npm run build
+
+after_script:
+  - npm run coveralls

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 TensorFlow implemented in Javascript
 
 [![Build Status](https://travis-ci.org/fongelias/tensor.svg?branch=master)](https://travis-ci.org/fongelias/tensor)
+[![Coverage Status](https://coveralls.io/repos/github/fongelias/tensor/badge.svg?branch=master)](https://coveralls.io/github/fongelias/tensor?branch=master)
 
 ## Process
 ### MNIST example

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "BABEL_ENV=test mocha --compilers js:babel-core/register ./**/*.test.js",
     "coverage": "BABEL_ENV=test nyc mocha --compilers js:babel-core/register ./**/*.test.js",
     "build": "BABEL_ENV=dev rollup -c",
-    "doc": "./node_modules/.bin/jsdoc ./lib/tensor/tensor.js"
+    "doc": "./node_modules/.bin/jsdoc ./lib/tensor/tensor.js",
+    "coveralls": "nyc report --reporter=text-lcov | coveralls"
   },
   "repository": {
     "type": "git",
@@ -29,6 +30,7 @@
     "babel-core": "^6.25.0",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-es2015": "^6.24.1",
+    "coveralls": "^2.13.1",
     "jsdoc": "^3.4.3",
     "mocha": "^3.4.1",
     "nyc": "^11.0.3",


### PR DESCRIPTION
Adds coveralls coverage reporting.
May need to change the `.travis.yml` file to run `npm run coverage` for the test step.
And change the mocha path parameter to `./lib/**/*.test.js` to avoid testing the packages in `node_modules/`.